### PR TITLE
Add Users table to stats.db

### DIFF
--- a/bin/stats.sh
+++ b/bin/stats.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# populate database
+DB='stats.db'
+
+
+if [ ! -f "./var/$DB" ]
+then
+    mkdir -p var/log
+    sqlite3 ./var/$DB < ./share/stats.sql && \
+    python3 ./bin/stats_users_populate.py
+else
+    echo "$DB already exists"
+fi

--- a/bin/stats_users_populate.py
+++ b/bin/stats_users_populate.py
@@ -1,0 +1,23 @@
+import sqlite3
+import uuid
+from faker import Faker
+import sqlite_utils
+
+sqlite3.register_converter("GUID", lambda b: uuid.UUID(bytes_le=b))
+sqlite3.register_adapter(uuid.UUID, lambda u: u.bytes_le)
+
+fake = Faker()
+fake.seed(0)
+
+num_users = 10000
+
+fake_users = [
+    {
+        "user_id": str(uuid.uuid4()),
+        "username": fake.user_name(),
+    }
+    for x in range(num_users)
+]
+
+db = sqlite_utils.Database("./var/stats.db")
+db["users"].insert_all(fake_users)

--- a/share/stats.sql
+++ b/share/stats.sql
@@ -1,0 +1,79 @@
+PRAGMA foreign_keys = ON;
+
+DROP VIEW IF EXISTS wins;
+DROP VIEW IF EXISTS streaks;
+DROP TABLE IF EXISTS users;
+DROP TABLE IF EXISTS games;
+
+CREATE TABLE users(
+    user_id GUID PRIMARY KEY, 
+    username VARCHAR 
+);
+
+CREATE TABLE games(
+    user_id GUID NOT NULL,
+    game_id INTEGER NOT NULL,
+    finished DATE DEFAULT CURRENT_TIMESTAMP,
+    guesses INTEGER,
+    won BOOLEAN,
+    PRIMARY KEY(user_id, game_id),
+    FOREIGN KEY(user_id) REFERENCES users(user_id)
+);
+
+CREATE INDEX games_won_idx ON games(won);
+
+CREATE VIEW wins
+AS
+    SELECT
+        user_id,
+        COUNT(won)
+    FROM
+        games
+    WHERE
+        won = TRUE
+    GROUP BY
+        user_id
+    ORDER BY
+        COUNT(won) DESC;
+
+CREATE VIEW streaks
+AS
+    WITH ranks AS (
+        SELECT DISTINCT
+            user_id,
+            finished,
+            RANK() OVER(PARTITION BY user_id ORDER BY finished) AS rank
+        FROM
+            games
+        WHERE
+            won = TRUE
+        ORDER BY
+            user_id,
+            finished
+    ),
+    groups AS (
+        SELECT
+            user_id,
+            finished,
+            rank,
+            DATE(finished, '-' || rank || ' DAYS') AS base_date
+        FROM
+            ranks
+    )
+    SELECT
+        user_id,
+        COUNT(*) AS streak,
+        MIN(finished) AS beginning,
+        MAX(finished) AS ending
+    FROM
+        groups
+    GROUP BY
+        user_id, base_date
+    HAVING
+        streak > 1
+    ORDER BY
+        user_id,
+        finished;
+
+PRAGMA analysis_limit=1000;
+PRAGMA optimize;


### PR DESCRIPTION
## PR Checklist

#### Tests

- [ ] tested services
  - [x] functions working for this feature
  - [ ] autodocumentation works
- [ ] tested configuration
  - [ ] launches services
  - [ ] reverse proxy
  - [ ] load balancing

#### Design Requirements

- [ ] input/output representations in json format

- [x] maintains statelessness (independent services)
  - [x] separate python files for each service
  - [ ] doesn't store current day's answer on the server side
  - [ ] doesn't track number of guesses made by a client

#### Readability / Maintainability

- [ ] commented code
- [x] follows PEP8 style / passes linting checks

## Description

#44 - stats.db

Closes #...

#### Changes
- add users table using UUID 
