### PR TITLE
Add game state service

### DIFF
--- a/.foreman
+++ b/.foreman
@@ -1,1 +1,1 @@
-formation: traefik=1,word_validation=1,answer_checking=1,stats=3
+formation: traefik=1,word_validation=1,answer_checking=1,stats=3, game_state=1

--- a/Procfile
+++ b/Procfile
@@ -2,3 +2,4 @@ traefik: ./traefik --configFile=./etc/traefik.toml
 word_validation: uvicorn --port $PORT --env-file="./api/words.env" --app-dir="./api" words:app --reload
 answer_checking: uvicorn --port $PORT --env-file="./api/answers.env" --app-dir="./api" answers:app --reload
 stats: uvicorn --port $PORT --env-file="./api/stats.env" --app-dir="./api"  stats:app --reload
+game_state: uvicorn --port $PORT --app-dir="./api"  game_state:app --reload

--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@
 
 1. `sudo service cron start` to start cron if it's not already running
 2. run `./bin/init.sh` from project root directory
-3. `foreman start --env openapi.env` to access with autodocumentation
+3. `foreman start`

--- a/api/answers.py
+++ b/api/answers.py
@@ -18,7 +18,7 @@ from typing import Optional
 class Settings(BaseSettings):
     database: str
     logging_config: str
-    openapi_url: str = ""
+    openapi_url: str = "/openapi.json"
 
     class Config:
         env_file = "answers.env"

--- a/api/game_state.env
+++ b/api/game_state.env
@@ -1,0 +1,1 @@
+LOGGING_CONFIG=./etc/logging.ini

--- a/api/game_state.py
+++ b/api/game_state.py
@@ -1,0 +1,88 @@
+from fastapi import FastAPI, Depends, Response, HTTPException, status, Body
+from pydantic import BaseModel, BaseSettings
+import redis
+import json
+from typing import Optional
+
+
+class Settings(BaseSettings):
+    logging_config: str = ""
+    openapi_url: str = "/openapi.json"
+
+    class Config:
+        env_file = "game_state.env"
+
+
+settings = Settings()
+app = FastAPI(root_path="/api/state", openapi_url=settings.openapi_url)
+# start connection to redis server
+r = redis.Redis(host="localhost", port=6379, db=0)
+
+# defines a new game in request body
+class Game(BaseModel):
+    user_id: str
+    game_id: int
+
+
+# get game status
+@app.get("/game/")
+def get_game(user_id: str, game_id: int):
+    res = r.hmget(user_id, game_id)
+    # if game is already played return error
+    if res[0] == None:
+        raise HTTPException(status_code=400, detail="User has not started this game.")
+    # gets game object from redis
+    game_information = json.loads(res[0])
+    return game_information
+
+
+# start a new game
+@app.post("/game/")
+def new_game(game: Game):
+    res = r.hmget(game.user_id, game.game_id)
+    if res[0] != None:
+        raise HTTPException(
+            status_code=409, detail="Game ID already exists for this user"
+        )
+    # create new game in json format so it can be set in redis
+    new_game = {
+        "status": "new",
+        "user_id": game.user_id,
+        "game_id": game.game_id,
+        "guesses_left": 6,
+        "words_guessed": [],
+    }
+    mapping = json.dumps(new_game)
+    # set the new game object with user_id as the key
+    r.hmset(
+        game.user_id,
+        {game.game_id: mapping},
+    )
+    return new_game
+
+
+@app.post("/game/update")
+def add_guess(guess: str, game: Game):
+    res = r.hmget(game.user_id, game.game_id)
+    # if game is already played return error
+    if res[0] == None:
+        raise HTTPException(status_code=400, detail="Failed to add guess")
+    # gets game object from redis
+    game_information = json.loads(res[0])
+    # check if game is already complete
+    if game_information["status"] == "finished":
+        raise HTTPException(status_code=400, detail="This game has ended")
+    # add new guess and update remaining attempts
+    game_information["guesses_left"] -= 1
+    game_information["words_guessed"].append(guess)
+    # update status
+    game_information["status"] = "in-progress"
+    if game_information["guesses_left"] == 0:
+        game_information["status"] = "finished"
+    # save changes
+    mapping = json.dumps(game_information)
+    r.hmset(
+        game.user_id,
+        {game.game_id: mapping},
+    )
+    return game_information

--- a/api/stats.py
+++ b/api/stats.py
@@ -21,7 +21,7 @@ class Settings(BaseSettings):
     database_dir: str
     logging_config: str
     shards: int
-    openapi_url: str = ""
+    openapi_url: str = "/openapi.json"
 
     class Config:
         env_file = "stats.env"

--- a/api/words.py
+++ b/api/words.py
@@ -9,7 +9,7 @@ from pydantic import BaseSettings
 class Settings(BaseSettings):
     database: str
     logging_config: str
-    openapi_url: str = ""
+    openapi_url: str = "/openapi.json"
 
     class Config:
         env_file = "words.env"

--- a/etc/routes.toml
+++ b/etc/routes.toml
@@ -2,9 +2,14 @@
   [http.middlewares]
 
     [http.middlewares.api-stripprefix.stripPrefix]
-      prefixes = ["/api/statistics", "/api/word", "/api/answer"]
+      prefixes = ["/api/statistics", "/api/word", "/api/answer", "/api/state"]
 
   [http.routers]
+
+    [http.routers.words]
+      service = "words"
+      rule = "PathPrefix(`/api/word`) || PathPrefix(`/words`)"
+      middlewares = ["api-stripprefix"] 
 
     [http.routers.answers]
       service = "answers"
@@ -15,11 +20,11 @@
       service = "statistics"
       rule = "PathPrefix(`/api/statistics`) || PathPrefix(`/users`) || PathPrefix(`/top10`)"
       middlewares = ["api-stripprefix"]
-
-    [http.routers.words]
-      service = "words"
-      rule = "PathPrefix(`/api/word`) || PathPrefix(`/words`)"
-      middlewares = ["api-stripprefix"]     
+    
+    [http.routers.state]
+      service = "state"
+      rule = "PathPrefix(`/api/state`)"
+      middlewares = ["api-stripprefix"] 
 
   [http.services]
 
@@ -41,3 +46,8 @@
           url = "http://127.0.0.1:5301"
         [[http.services.statistics.loadBalancer.servers]]
           url = "http://127.0.0.1:5302"
+
+    [http.services.state]
+      [http.services.state.loadBalancer]
+        [[http.services.state.loadBalancer.servers]]
+          url = "http://127.0.0.1:5400"

--- a/openapi.env
+++ b/openapi.env
@@ -1,1 +1,1 @@
-OPENAPI_URL=/openapi.json
+OPENAPI_URL=


### PR DESCRIPTION
## PR Checklist

#### Tests

- [x] tested services
  - [x] functions working for this feature
  - [x] autodocumentation works
- [x] tested configuration
  - [x] launches services
  - [x] reverse proxy
  - [x] load balancing
  - [x] runs cron job

#### Design Requirements

- [x] input/output representations in json format

- [x] maintains statelessness (independent services)
  - [x] separate python files for each service
  - [x] Answer Service doesn't store current day's answer on the server side
  - [x] Answer Service doesn't track number of guesses made by a client

#### Readability / Maintainability

- [x] commented code
- [x] follows PEP8 style / passes linting checks

## Description

Closes #73 
Closes #74 
Closes #72 

#### Changes

- add get game state for user game
- add create new game for user
- add update game with new guess
