### PR TITLE
Update answers.db to use int date instead of string date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Change UPDATE game in game_state to use game_id in path
 - Changed settings in services to contain default values when not using .env files
 - Changed response model in game state to use GameState model instead of Game input model and State output model
+- Changed answers.db to use int as date instead of string
 
 ### Removed
 

--- a/api/answers.py
+++ b/api/answers.py
@@ -23,7 +23,7 @@ class Settings(BaseSettings):
 
 
 class Answer(BaseModel):
-    day: Optional[str] = datetime.date.today().strftime("%Y-%m-%d")
+    day: int = int(datetime.date.today().strftime("%Y%m%d"))
     word: str
 
 
@@ -53,7 +53,7 @@ def get_logger():
 
 # get WOTD based on the date parameter entered
 @app.get("/answers/{day}")
-def get_answer(day: str, response: Response, db: sqlite3.Connection = Depends(get_db)):
+def get_answer(day: int, response: Response, db: sqlite3.Connection = Depends(get_db)):
     cur = db.execute("SELECT word FROM answers WHERE day = ?", [day])
     wotd = cur.fetchall()
     if not wotd:
@@ -95,7 +95,7 @@ def change_answer(
 @app.get("/check/{guess}", response_model=Check)
 def find_answer(
     guess: str,
-    day: str = datetime.date.today().strftime("%Y-%m-%d"),
+    day: int = int(datetime.date.today().strftime("%Y%m%d")),
     db: sqlite3.Connection = Depends(get_db),
     logger: logging.Logger = Depends(get_logger),
 ):

--- a/bin/python/date_gen.py
+++ b/bin/python/date_gen.py
@@ -6,5 +6,5 @@ def convert(value):
 
     # start_day = date.today();
     start_day = date.fromisoformat("2021-12-31")
-    day = (start_day + timedelta(days=(value))).strftime("%Y-%m-%d")
-    return day
+    day = (start_day + timedelta(days=(value))).strftime("%Y%m%d")
+    return int(day)


### PR DESCRIPTION
## PR Checklist

#### Tests

- [ ] tested services
  - [ ] functions working for this feature
  - [ ] autodocumentation works
- [ ] tested configuration
  - [ ] launches services
  - [ ] reverse proxy
  - [ ] load balancing
  - [ ] runs cron job

#### Design Requirements

- [ ] input/output representations in json format
- [ ] BFF service doesn't access database (SQL or Redis)
- [ ] maintains statelessness (independent services)
  - [ ] separate python files for each service
  - [ ] Answer Service doesn't store current day's answer on the server side
  - [ ] Answer Service doesn't track number of guesses made by a client

#### Readability / Maintainability

- [ ] commented code
- [ ] follows PEP8 style / passes linting checks

## Description

Closes #...

#### Changes

- use int date to correspond to gameid
