### PR TITLE
Add new game and new guess endpoints to functions for corresponding workflows

### DIFF
--- a/.foreman
+++ b/.foreman
@@ -1,1 +1,1 @@
-formation: traefik=1,word_validation=1,answer_checking=1,stats=3, game_state=1
+formation: traefik=1,word_validation=1,answer_checking=1,stats=3, game_state=1, bff=1

--- a/Procfile
+++ b/Procfile
@@ -3,3 +3,4 @@ word_validation: uvicorn --port $PORT --env-file="./api/words.env" --app-dir="./
 answer_checking: uvicorn --port $PORT --env-file="./api/answers.env" --app-dir="./api" answers:app --reload
 stats: uvicorn --port $PORT --env-file="./api/stats.env" --app-dir="./api"  stats:app --reload
 game_state: uvicorn --port $PORT --app-dir="./api"  game_state:app --reload
+bff: uvicorn --port $PORT --app-dir="./api" bff:app --reload

--- a/api/game_state.py
+++ b/api/game_state.py
@@ -82,7 +82,7 @@ def get_game(user_id: str, game_id: int):
 @app.post(
     "/game/new",
     response_model=GameState,
-    response_model_exclude_defaults=True,
+    response_model_exclude=["remaining", "guesses"],
     responses={
         403: {
             "model": Message,

--- a/etc/routes.toml
+++ b/etc/routes.toml
@@ -2,28 +2,33 @@
   [http.middlewares]
 
     [http.middlewares.api-stripprefix.stripPrefix]
-      prefixes = ["/api/statistics", "/api/word", "/api/answer", "/api/state"]
+      prefixes = ["/api/statistics", "/api/word", "/api/answer", "/api/state", "/api/bff"]
 
   [http.routers]
 
     [http.routers.words]
       service = "words"
-      rule = "PathPrefix(`/api/word`) || PathPrefix(`/words`)"
+      rule = "PathPrefix(`/api/word`)"
       middlewares = ["api-stripprefix"] 
 
     [http.routers.answers]
       service = "answers"
-      rule = "PathPrefix(`/api/answer`) || PathPrefix(`/answers`) || PathPrefix(`/check`)"
+      rule = "PathPrefix(`/api/answer`)"
       middlewares = ["api-stripprefix"]
 
     [http.routers.stats]
       service = "statistics"
-      rule = "PathPrefix(`/api/statistics`) || PathPrefix(`/users`) || PathPrefix(`/top10`)"
+      rule = "PathPrefix(`/api/statistics`)"
       middlewares = ["api-stripprefix"]
     
     [http.routers.state]
       service = "state"
       rule = "PathPrefix(`/api/state`)"
+      middlewares = ["api-stripprefix"] 
+
+    [http.routers.bff]
+      service = "bff"
+      rule = "PathPrefix(`/api/bff`)"
       middlewares = ["api-stripprefix"] 
 
   [http.services]
@@ -51,3 +56,9 @@
       [http.services.state.loadBalancer]
         [[http.services.state.loadBalancer.servers]]
           url = "http://127.0.0.1:5400"
+
+    [http.services.bff]
+      [http.services.bff.loadBalancer]
+        [[http.services.bff.loadBalancer.servers]]
+          url = "http://127.0.0.1:5500"
+


### PR DESCRIPTION
## PR Checklist

#### Tests

- [x] tested services
  - [x] functions working for this feature
  - [x] autodocumentation works
- [x] tested configuration
  - [x] launches services
  - [x] reverse proxy
  - [x] load balancing
  - [x] runs cron job

#### Design Requirements

- [x] input/output representations in json format
- [x] BFF service doesn't access database (SQL or Redis)
- [x] maintains statelessness (independent services)
  - [x] separate python files for each service
  - [x] Answer Service doesn't store current day's answer on the server side
  - [x] Answer Service doesn't track number of guesses made by a client

#### Readability / Maintainability

- [x] commented code
- [x] follows PEP8 style / passes linting checks

## Description

Closes #82 , Closes #81 

#### Changes

- add fastapi/endpoints for new_game and new_guess workflow functions
- add foreman config for bff
- add traefik config for bff
- update response model for create game in game state service